### PR TITLE
feat: really use `ruff` instead of `ruff_lsp` (#4)

### DIFF
--- a/kickstart-python.lua
+++ b/kickstart-python.lua
@@ -90,7 +90,7 @@ local plugins = {
 			-- ruff uses an LSP proxy, therefore it needs to be enabled as if it
 			-- were a LSP. In practice, ruff only provides linter-like diagnostics
 			-- and some code actions, and is not a full LSP yet.
-			require("lspconfig").ruff_lsp.setup({
+			require("lspconfig").ruff.setup({
 				-- organize imports disabled, since we are already using `isort` for that
 				-- alternative, this can be enabled to make `organize imports`
 				-- available as code action


### PR DESCRIPTION
This commit prevents the following error:
/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:800: Spawning language server with cmd: `{ "ruff-lsp" }` failed. The language server is either not installed, missing from PATH, or not executable.

and will allow the attachment of the new ruff server when editing Python files.