### PR TITLE
Revert "improv: use lazy.nvim's recommended bootstrap (better fix for…

### DIFF
--- a/kickstart-python.lua
+++ b/kickstart-python.lua
@@ -1,5 +1,11 @@
--- BOOTSTRAP LAZY.NVIM https://lazy.folke.io/developers#bootstrap
-load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
+-- BOOTSTRAP the plugin manager `lazy.nvim`
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.uv.fs_stat(lazypath) then
+	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+	local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+	if vim.v.shell_error ~= 0 then error("Error cloning lazy.nvim:\n" .. out) end
+end
+vim.opt.runtimepath:prepend(lazypath)
 
 --------------------------------------------------------------------------------
 -- BASIC PYTHON-RELATED OPTIONS


### PR DESCRIPTION
… #3)"

This reverts commit 0d569e5da47d05431fd5f133f857369ed09ab86e.

Downloading the lazy bootstrap code everytime that nvim is executed completely breaks neovim if the user is offline or in networks with resticted internet access. The uncached usage of the bootstrap code is also not cost-effective.